### PR TITLE
feat: Add Stainless Open Source Program

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Free tools, services, and credits offered to open-source projects and their main
 - [JetBrains](https://www.jetbrains.com/community/opensource/) - Free All Products Pack IDE subscriptions for core project teams.
 - [Mintlify](https://www.mintlify.com/oss-program) - Free Pro plan for non-commercial OSS projects (custom domains, analytics, API playground, AI chat).
 - [Sanity](https://www.sanity.io/docs/open-source-plan) - Free Growth plan for non-monetized OSS projects with 3 datasets, 25 users, and SAML SSO.
+- [Stainless](https://stainless.com/pricing) - Free SDK, documentation site, and MCP server generation from OpenAPI specs for open-source projects, with up to 5 generators and 100 preview builds per month.
 
 ## Funding
 

--- a/packages/core/src/programs/stainless-open-source-program.json
+++ b/packages/core/src/programs/stainless-open-source-program.json
@@ -1,0 +1,35 @@
+{
+  "category": "devtools",
+  "description": "Free SDK, documentation site, and MCP server generation from OpenAPI specs for open-source projects, with up to 5 generators and 100 preview builds per month.",
+  "eligibility": [
+    "Project must have a public OpenAPI specification.\n",
+    "Must be publicly available under a recognized open-source license."
+  ],
+  "name": "Stainless Open Source Program",
+  "perks": [
+    {
+      "description": "Up to 5 generators for TypeScript, Python, Go, Java, Kotlin, Ruby, and C# SDKs at no cost.",
+      "title": "SDK Generation"
+    },
+    {
+      "description": "Auto-generated API documentation and MCP servers from your OpenAPI spec.",
+      "title": "Documentation Sites"
+    },
+    {
+      "description": "100 preview builds per month with a 25/day rate limit for testing SDK changes.",
+      "title": "Preview Builds"
+    }
+  ],
+  "provider": "Stainless",
+  "slug": "stainless-open-source-program",
+  "tags": [
+    "open-source",
+    "developer-tools",
+    "api"
+  ],
+  "url": "https://stainless.com/pricing",
+  "applicationProcess": [
+    "Sign up at stainless.com with your GitHub account.",
+    "Connect your OpenAPI spec and configure your generators on the free Hobby plan."
+  ]
+}

--- a/packages/core/src/programs/stainless-open-source-program.json
+++ b/packages/core/src/programs/stainless-open-source-program.json
@@ -2,7 +2,7 @@
   "category": "devtools",
   "description": "Free SDK, documentation site, and MCP server generation from OpenAPI specs for open-source projects, with up to 5 generators and 100 preview builds per month.",
   "eligibility": [
-    "Project must have a public OpenAPI specification.\n",
+    "Project must have a public OpenAPI specification.",
     "Must be publicly available under a recognized open-source license."
   ],
   "name": "Stainless Open Source Program",
@@ -22,11 +22,7 @@
   ],
   "provider": "Stainless",
   "slug": "stainless-open-source-program",
-  "tags": [
-    "open-source",
-    "developer-tools",
-    "api"
-  ],
+  "tags": ["open-source", "developer-tools", "api"],
   "url": "https://stainless.com/pricing",
   "applicationProcess": [
     "Sign up at stainless.com with your GitHub account.",


### PR DESCRIPTION
## New Program Submission

**Program:** Stainless Open Source Program
**Provider:** Stainless
**Category:** devtools
**URL:** https://stainless.com/pricing
**Tags:** `open-source`, `developer-tools`, `api`

### Description
Free SDK, documentation site, and MCP server generation from OpenAPI specs for open-source projects, with up to 5 generators and 100 preview builds per month.

### Eligibility
- Project must have a public OpenAPI specification.
- Must be publicly available under a recognized open-source license.

### How to Apply
1. Sign up at stainless.com with your GitHub account.
2. Connect your OpenAPI spec and configure your generators on the free Hobby plan.

### Perks
- **SDK Generation**: Up to 5 generators for TypeScript, Python, Go, Java, Kotlin, Ruby, and C# SDKs at no cost.
- **Documentation Sites**: Auto-generated API documentation and MCP servers from your OpenAPI spec.
- **Preview Builds**: 100 preview builds per month with a 25/day rate limit for testing SDK changes.

---
*Submitted via the OSS Perks website.*
